### PR TITLE
Use sdcpy-map v0.1.1 lag-cube outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "sdcpy>=0.7.1",
-  "sdcpy-map @ git+https://github.com/AlFontal/sdcpy-map.git@main",
+  "sdcpy-map @ git+https://github.com/AlFontal/sdcpy-map.git@v0.1.1",
   "fastapi>=0.115.0",
   "uvicorn[standard]>=0.32.0",
   "jinja2>=3.1.0",

--- a/sdcpy_studio/service.py
+++ b/sdcpy_studio/service.py
@@ -1809,13 +1809,18 @@ def _build_event_map_netcdf_bytes(
                 raise ValueError(
                     "Positive and negative lag coordinates must match for NetCDF export."
                 )
-            corr_by_lag = np.asarray(lag_maps.get("corr_by_lag"), dtype=float)
-            event_count_by_lag = np.asarray(lag_maps.get("event_count_by_lag"), dtype=float)
-            data_vars[f"{sign_key}_corr_by_lag"] = (("lag", "lat", "lon"), corr_by_lag)
-            data_vars[f"{sign_key}_event_count_by_lag"] = (
-                ("lag", "lat", "lon"),
-                event_count_by_lag,
-            )
+            for key in (
+                "corr_by_lag",
+                "driver_rel_time_by_lag",
+                "timing_by_lag",
+                "event_count_by_lag",
+            ):
+                if key not in lag_maps:
+                    continue
+                data_vars[f"{sign_key}_{key}"] = (
+                    ("lag", "lat", "lon"),
+                    np.asarray(lag_maps.get(key), dtype=float),
+                )
 
     dataset = xr.Dataset(
         data_vars=data_vars,
@@ -1934,10 +1939,22 @@ def _build_map_lag_payload(
 ) -> dict:
     lags = np.asarray(lag_maps.get("lags") or [], dtype=int)
     corr_by_lag = lag_maps.get("corr_by_lag")
+    driver_rel_time_by_lag = lag_maps.get("driver_rel_time_by_lag")
+    timing_by_lag = lag_maps.get("timing_by_lag")
     event_count_by_lag = lag_maps.get("event_count_by_lag")
     corr_cube = (
         np.asarray(corr_by_lag, dtype=float)
         if corr_by_lag is not None
+        else np.full((len(lags), len(lats), len(lons)), np.nan, dtype=float)
+    )
+    driver_rel_time_cube = (
+        np.asarray(driver_rel_time_by_lag, dtype=float)
+        if driver_rel_time_by_lag is not None
+        else np.full((len(lags), len(lats), len(lons)), np.nan, dtype=float)
+    )
+    timing_cube = (
+        np.asarray(timing_by_lag, dtype=float)
+        if timing_by_lag is not None
         else np.full((len(lags), len(lats), len(lons)), np.nan, dtype=float)
     )
     event_count_cube = (
@@ -1951,6 +1968,8 @@ def _build_map_lag_payload(
         "lags": [int(v) for v in lags.tolist()],
         "coastline": _serialize_coastline_trace(coastline),
         "corr_by_lag": _serialize_optional_cube(corr_cube),
+        "driver_rel_time_by_lag": _serialize_optional_cube(driver_rel_time_cube),
+        "timing_by_lag": _serialize_optional_cube(timing_cube),
         "event_count_by_lag": _serialize_optional_cube(event_count_cube),
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import zipfile
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from uuid import uuid4
-import zipfile
 
 import numpy as np
 import pandas as pd
@@ -14,7 +14,12 @@ from fastapi.testclient import TestClient
 
 from sdcpy_studio.main import create_app
 from sdcpy_studio.schemas import SDCJobRequest
-from sdcpy_studio.service import build_sdc_map_exploration, run_sdc_job
+from sdcpy_studio.service import (
+    _build_event_map_netcdf_bytes,
+    _build_map_lag_payload,
+    build_sdc_map_exploration,
+    run_sdc_job,
+)
 
 
 class InlineJobManager:
@@ -228,6 +233,59 @@ def _series_payload(n: int = 80):
     return ts1.tolist(), ts2.tolist()
 
 
+def test_map_lag_payload_preserves_position_and_timing_cubes():
+    payload = _build_map_lag_payload(
+        lag_maps={
+            "lags": [0, 1],
+            "corr_by_lag": [[[0.4]], [[0.6]]],
+            "driver_rel_time_by_lag": [[[2.0]], [[3.0]]],
+            "timing_by_lag": [[[2.0]], [[2.0]]],
+            "event_count_by_lag": [[[1]], [[2]]],
+        },
+        lats=np.asarray([10.0]),
+        lons=np.asarray([20.0]),
+        coastline=None,
+    )
+
+    assert payload["driver_rel_time_by_lag"] == [[[2.0]], [[3.0]]]
+    assert payload["timing_by_lag"] == [[[2.0]], [[2.0]]]
+
+
+def test_event_map_netcdf_preserves_lag_position_and_timing_cubes():
+    xr = pytest.importorskip("xarray")
+    nc_bytes = _build_event_map_netcdf_bytes(
+        class_results={
+            "positive": {
+                "layers": {"corr_mean": np.asarray([[0.6]])},
+                "lag_maps": {
+                    "lags": [0, 1],
+                    "corr_by_lag": np.asarray([[[0.4]], [[0.6]]]),
+                    "driver_rel_time_by_lag": np.asarray([[[2.0]], [[3.0]]]),
+                    "timing_by_lag": np.asarray([[[2.0]], [[2.0]]]),
+                    "event_count_by_lag": np.asarray([[[1.0]], [[2.0]]]),
+                },
+            },
+            "negative": {
+                "layers": {"corr_mean": np.asarray([[-0.5]])},
+                "lag_maps": {
+                    "lags": [0, 1],
+                    "corr_by_lag": np.asarray([[[-0.3]], [[-0.5]]]),
+                    "driver_rel_time_by_lag": np.asarray([[[-1.0]], [[0.0]]]),
+                    "timing_by_lag": np.asarray([[[-1.0]], [[-1.0]]]),
+                    "event_count_by_lag": np.asarray([[[1.0]], [[1.0]]]),
+                },
+            },
+        },
+        lats=np.asarray([10.0]),
+        lons=np.asarray([20.0]),
+        attrs={"driver_dataset": "driver", "field_dataset": "field"},
+    )
+
+    ds = xr.open_dataset(BytesIO(nc_bytes))
+    assert float(ds["positive_driver_rel_time_by_lag"].sel(lag=1, lat=10.0, lon=20.0)) == pytest.approx(3.0)
+    assert float(ds["positive_timing_by_lag"].sel(lag=1, lat=10.0, lon=20.0)) == pytest.approx(2.0)
+
+
 def _custom_map_driver_csv(n: int = 72) -> str:
     rows = ["date,my_index,other"]
     for i in range(n):
@@ -243,6 +301,11 @@ def _custom_map_driver_three_series_month_end_csv(n: int = 12, start: str = "200
     for i, ts in enumerate(dates):
         rows.append(f"{ts.date()},{np.sin(i / 3):.6f},{np.cos(i / 4):.6f},{np.sin(i / 5):.6f}")
     return "\n".join(rows)
+
+
+def _dataset_to_netcdf_bytes(ds) -> bytes:
+    payload = ds.to_netcdf(engine="scipy")
+    return payload if isinstance(payload, bytes) else bytes(payload)
 
 
 def _custom_map_field_netcdf_bytes() -> bytes:
@@ -262,8 +325,7 @@ def _custom_map_field_netcdf_bytes() -> bytes:
         },
         coords={"time": times, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def _custom_map_field_monthly_2000_netcdf_bytes() -> bytes:
@@ -277,8 +339,7 @@ def _custom_map_field_monthly_2000_netcdf_bytes() -> bytes:
         data_vars={"sst_anom": (("time", "lat", "lon"), values.astype("float32"))},
         coords={"time": times, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def _custom_map_field_singleton_level_netcdf_bytes() -> bytes:
@@ -299,8 +360,7 @@ def _custom_map_field_singleton_level_netcdf_bytes() -> bytes:
         data_vars={"air": (("time", "level", "lat", "lon"), values.astype("float32"))},
         coords={"time": times, "level": levels, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def _custom_map_field_multilevel_netcdf_bytes() -> bytes:
@@ -321,8 +381,7 @@ def _custom_map_field_multilevel_netcdf_bytes() -> bytes:
         data_vars={"air": (("time", "level", "lat", "lon"), values.astype("float32"))},
         coords={"time": times, "level": levels, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def _custom_map_field_multilevel_without_coord_netcdf_bytes() -> bytes:
@@ -337,8 +396,7 @@ def _custom_map_field_multilevel_without_coord_netcdf_bytes() -> bytes:
         data_vars={"air": (("time", "member", "lat", "lon"), values)},
         coords={"time": times, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def _custom_map_field_climatology_netcdf_bytes() -> bytes:
@@ -366,8 +424,7 @@ def _custom_map_field_climatology_netcdf_bytes() -> bytes:
         },
         coords={"time": time, "lat": lats, "lon": lons},
     )
-    payload = ds.to_netcdf()
-    return payload if isinstance(payload, bytes) else bytes(payload)
+    return _dataset_to_netcdf_bytes(ds)
 
 
 def test_root_page_renders():

--- a/uv.lock
+++ b/uv.lock
@@ -1363,8 +1363,8 @@ wheels = [
 
 [[package]]
 name = "sdcpy-map"
-version = "0.1.0"
-source = { git = "https://github.com/AlFontal/sdcpy-map.git?rev=main#3feb2b331794b80bf621381a9c1328140b4ea194" }
+version = "0.1.1"
+source = { git = "https://github.com/AlFontal/sdcpy-map.git?rev=v0.1.1#1dc04d0f9622fc60ee792e77e059a72cbcbeb93d" }
 dependencies = [
     { name = "geopandas" },
     { name = "h5netcdf" },
@@ -1423,7 +1423,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "sdcpy", specifier = ">=0.7.1" },
-    { name = "sdcpy-map", git = "https://github.com/AlFontal/sdcpy-map.git?rev=main" },
+    { name = "sdcpy-map", git = "https://github.com/AlFontal/sdcpy-map.git?rev=v0.1.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

- depend on the versioned `sdcpy-map` release tag `v0.1.1` instead of `@main`
- preserve lag-resolved driver-relative position and timing cubes in Studio API payloads
- include the new lag companion cubes in NetCDF exports
- add API tests for lag payload and NetCDF preservation
- make test NetCDF upload fixtures use an explicit `scipy` writer to avoid CI-only netCDF4/HDF in-memory write failures

## Why

`sdcpy-map v0.1.1` makes the lag-resolved peak-averaged cube the canonical source for static A/B/C/D maps. Studio needs to preserve the new companion arrays so downstream reports and exports remain consistent with that calculation.

The CI failure was caused by fixture generation relying on xarray's default in-memory `netcdf4` writer, which raises `RuntimeError: NetCDF: HDF error` on the GitHub Actions dependency stack. The fixtures now use a deterministic in-memory writer.

## Validation

- `uv run python` import check: `sdcpy-map 0.1.1` from installed package path
- `uv run pytest tests/test_api.py -k "map_lag_payload or event_map_netcdf"`
- `uv run pytest tests/test_api.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache uv run ruff check tests/test_api.py`
- `RUFF_CACHE_DIR=/private/tmp/ruff-cache uv run ruff check sdcpy_studio/service.py tests/test_api.py pyproject.toml`